### PR TITLE
storage/dev.h: use device driver context instead of id

### DIFF
--- a/libstorage/include/storage/dev.h
+++ b/libstorage/include/storage/dev.h
@@ -18,6 +18,7 @@
 
 
 struct _storage_t;
+struct _storage_devCtx_t; /* Device driver context should be defined by flash driver */
 
 
 /* Block device interface */
@@ -80,9 +81,9 @@ typedef struct {
 /* Storage device structure */
 
 typedef struct {
-	unsigned int id;    /* Field allows to identify several devices within one driver */
-	storage_blk_t *blk; /* Block device context */
-	storage_mtd_t *mtd; /* MTD device context */
+	storage_blk_t *blk;            /* Block device context */
+	storage_mtd_t *mtd;            /* MTD device context */
+	struct _storage_devCtx_t *ctx; /* Device driver context */
 } storage_dev_t;
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
`_storage_devCtx_t` defines data used by specific flash memory driver.

PD-216


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (zynq7000).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
