### PR TITLE
libvga: Fix infinite loop in `graph_colorset/get()`

### DIFF
--- a/libgraph/cirrus.c
+++ b/libgraph/cirrus.c
@@ -317,7 +317,7 @@ int cirrus_colorset(graph_t *graph, const unsigned char *colors, unsigned char f
 {
 	cirrus_dev_t *cdev = (cirrus_dev_t *)graph->adapter;
 	void *ctx = cdev->ctx;
-	unsigned char i;
+	unsigned int i;
 
 	if (graph->depth != 1)
 		return -ENOTSUP;
@@ -342,7 +342,7 @@ int cirrus_colorget(graph_t *graph, unsigned char *colors, unsigned char first, 
 {
 	cirrus_dev_t *cdev = (cirrus_dev_t *)graph->adapter;
 	void *ctx = cdev->ctx;
-	unsigned char i;
+	unsigned int i;
 
 	if (graph->depth != 1)
 		return -ENOTSUP;

--- a/libgraph/vga.c
+++ b/libgraph/vga.c
@@ -167,7 +167,7 @@ int vga_colorset(graph_t *graph, const unsigned char *colors, unsigned char firs
 {
 	vga_dev_t *vga = (vga_dev_t *)graph->adapter;
 	void *ctx = vga->ctx;
-	unsigned char i;
+	unsigned int i;
 
 	if (graph->depth != 1)
 		return -ENOTSUP;
@@ -192,7 +192,7 @@ int vga_colorget(graph_t *graph, unsigned char *colors, unsigned char first, uns
 {
 	vga_dev_t *vga = (vga_dev_t *)graph->adapter;
 	void *ctx = vga->ctx;
-	unsigned char i;
+	unsigned int i;
 
 	if (graph->depth != 1)
 		return -ENOTSUP;


### PR DESCRIPTION
Fix endless loop when set or get the (full) 256 color palette.

Example case when error occurred:
```C
/* for (8-bit palette) indexed 256 color mode */
unsigned char palette[3 * 256];
...
graph_colorset(graph, palette, 0, 255);
```

JIRA: RTOS-186

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
