### PR TITLE
libmtd & libstorage: update strogae_mtd_t and mtd functions

### DIFF
--- a/libstorage/include/storage/dev.h
+++ b/libstorage/include/storage/dev.h
@@ -73,7 +73,8 @@ typedef struct {
 	size_t writesz;              /* Minimal writable flash unit size. For NOR it is 1, for NAND it is one page */
 	size_t writeBuffsz;          /* For NOR flash it is page size, for NAND should be equal writesz */
 	size_t metaSize;             /* Amount of meta data per block */
-	size_t metaAvail;            /* Available meta data per block */
+	size_t oobSize;              /* out-of-bound (oob) data size */
+	size_t oobAvail;             /* available out-of-bound (oob) data size */
 	const storage_mtdops_t *ops; /* Pointer to operations on the MTD device */
 } storage_mtd_t;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
 - the `oobSize` and the `oobAvail` fields are added into storage_mtd_t - there are needed for a NAND driver
 - instead of adding a partition offset in a driver implementation, it has been moved to a higher layer
 - small changes in `mtd_oob*` functions

DTR-102

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [x] I will merge this PR by myself when appropriate.
