### PR TITLE
libmtd &libstorage: pass retlen as argument to mtd read and write functions

### DIFF
--- a/libmtd/mtd.c
+++ b/libmtd/mtd.c
@@ -150,14 +150,10 @@ int mtd_read(struct mtd_info *mtdInfo, off_t from, size_t len, size_t *retlen, u
 		ret = EOK;
 	}
 	else {
-		ret = mtd->ops->read(mtdInfo->storage, mtdInfo->storage->start + from, buf, len);
+		ret = mtd->ops->read(mtdInfo->storage, mtdInfo->storage->start + from, buf, len, retlen);
 	}
 
-	if (ret > 0) {
-		*retlen = ret;
-	}
-
-	return ret >= 0 ? EOK : ret;
+	return ret;
 }
 
 
@@ -177,14 +173,10 @@ int mtd_write(struct mtd_info *mtdInfo, off_t to, size_t len, size_t *retlen, co
 		ret = EOK;
 	}
 	else {
-		ret = mtd->ops->write(mtdInfo->storage, mtdInfo->storage->start + to, buf, len);
+		ret = mtd->ops->write(mtdInfo->storage, mtdInfo->storage->start + to, buf, len, retlen);
 	}
 
-	if (ret > 0) {
-		*retlen = ret;
-	}
-
-	return ret >= 0 ? EOK : ret;
+	return ret;
 }
 
 
@@ -222,13 +214,10 @@ int mtd_read_oob(struct mtd_info *mtdInfo, off_t from, struct mtd_oob_ops *ops)
 	}
 
 	if (ret >= 0) {
-		ret = mtd->ops->meta_read(mtdInfo->storage, mtdInfo->storage->start + from, ops->oobbuf, ops->ooblen);
-		if (ret > 0) {
-			ops->oobretlen = ret;
-		}
+		ret = mtd->ops->meta_read(mtdInfo->storage, mtdInfo->storage->start + from, ops->oobbuf, ops->ooblen, &ops->oobretlen);
 	}
 
-	return ret >= 0 ? EOK : ret;
+	return ret;
 }
 
 
@@ -249,13 +238,10 @@ int mtd_write_oob(struct mtd_info *mtdInfo, off_t to, struct mtd_oob_ops *ops)
 	}
 
 	if (ret >= 0) {
-		ret = mtd->ops->meta_write(mtdInfo->storage, mtdInfo->storage->start + to, ops->oobbuf, ops->ooblen);
-		if (ret > 0) {
-			ops->oobretlen = ret;
-		}
+		ret = mtd->ops->meta_write(mtdInfo->storage, mtdInfo->storage->start + to, ops->oobbuf, ops->ooblen, &ops->oobretlen);
 	}
 
-	return ret >= 0 ? EOK : ret;
+	return ret;
 }
 
 

--- a/libstorage/include/storage/dev.h
+++ b/libstorage/include/storage/dev.h
@@ -41,11 +41,11 @@ typedef struct {
 	int (*erase)(struct _storage_t *dev, off_t offs, size_t size);
 	int (*unPoint)(struct _storage_t *dev, off_t offs, size_t size);
 	ssize_t (*point)(struct _storage_t *dev, off_t offs, size_t size, size_t *retlen, void **virt, addr_t *phys);
-	ssize_t (*read)(struct _storage_t *dev, off_t offs, void *data, size_t len);
-	ssize_t (*write)(struct _storage_t *dev, off_t offs, const void *data, size_t len);
+	int (*read)(struct _storage_t *dev, off_t offs, void *data, size_t len, size_t *retlen);
+	int (*write)(struct _storage_t *dev, off_t offs, const void *data, size_t len, size_t *retlen);
 
-	ssize_t (*meta_read)(struct _storage_t *dev, off_t offs, void *data, size_t len);
-	ssize_t (*meta_write)(struct _storage_t *dev, off_t offs, const void *data, size_t len);
+	int (*meta_read)(struct _storage_t *dev, off_t offs, void *data, size_t len, size_t *retlen);
+	int (*meta_write)(struct _storage_t *dev, off_t offs, const void *data, size_t len, size_t *retlen);
 
 	void (*sync)(struct _storage_t *dev);
 	int (*lock)(struct _storage_t *dev, off_t offs, size_t len);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Changes in the interface are needed to correctly handle ECC errors for NAND flash memory.

DTR-102, PD-216

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
