### PR TITLE
libuuid: decrease the execution time of uuid_useRand()

### DIFF
--- a/libuuid/uuid.c
+++ b/libuuid/uuid.c
@@ -70,7 +70,7 @@ static void uuid_useRand(uuid_t out)
 	}
 
 	/* to prevent same numbers when using the same seed */
-	n = (int)(ts.tv_nsec / 100);
+	n = (int)(ts.tv_nsec / (1000 * 1000));
 	for (i = 0; i < n; i++) {
 		rand();
 	}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

- libuuid: decrease the execution time of uuid_useRand()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Generating large amount of uuids (test-libuuid) on targets, where /dev/random is not present took more time.
The tv_nsec resolution is commonly lower than or equal to 1ms, so the change does not decrease usability.

DONE: RTOS-235

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7a9-zynq7000-zedboard).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
