### PR TITLE
libuuid: avoid setting the same seed

### DIFF
--- a/libuuid/uuid.c
+++ b/libuuid/uuid.c
@@ -63,8 +63,7 @@ static void uuid_useRand(uuid_t out)
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	pid = getpid();
 
-	/* only if (pid2 == 255 + n*pid1) and the first 24 bits of tv_sec were the same it could be the same seed */
-	if (init == 1 || (rand() % 2) == 1) {
+	if (init == 1) {
 		srand((unsigned int)((ts.tv_sec & 0x0FFF) | (pid << 24)));
 		init = 0;
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

 - libuuid: avoid setting the same seed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The problem with generating same uuids might have occurred, when not using `/dev/random`. The change solves it.

JIRA: RTOS-239

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7a9-zynq7000-zedboard).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
