### PR TITLE
libmtd: change type of argument in mtd_point function

### DIFF
--- a/libmtd/include/mtd/mtd.h
+++ b/libmtd/include/mtd/mtd.h
@@ -105,7 +105,7 @@ extern int mtd_erase(struct mtd_info *mtd, struct erase_info *instr);
 
 /* Function for eXecute-In-Place mechanism. Phys is optional and may be set to NULL */
 extern int mtd_point(struct mtd_info *mtd, off_t from, size_t len, size_t *retlen,
-	void **virt, size_t *phys);
+	void **virt, addr_t *phys);
 
 
 /* Unpoint selected memory area */

--- a/libmtd/mtd.c
+++ b/libmtd/mtd.c
@@ -62,7 +62,7 @@ int mtd_erase(struct mtd_info *mtdInfo, struct erase_info *instr)
 }
 
 
-int mtd_point(struct mtd_info *mtdInfo, off_t from, size_t len, size_t *retlen, void **virt, size_t *phys)
+int mtd_point(struct mtd_info *mtdInfo, off_t from, size_t len, size_t *retlen, void **virt, addr_t *phys)
 {
 	int ret;
 	storage_mtd_t *mtd = mtdInfo->storage->dev->mtd;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Based on linux mtd API argument `phys` is a type of `resource_size_t;`
`resource_size_t` is a typedef to `phys_addr_t`. For this reason, type of `phys` argument in `mtd_point` is changed to `addr_t`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Wrong argument type causes warning on `ia32-generic-pc` target.

RTOS-244
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
