### PR TITLE
Change cache_init function header in libcache API

### DIFF
--- a/libcache/cache.c
+++ b/libcache/cache.c
@@ -78,7 +78,7 @@ struct cachectx_s {
 
 	size_t srcMemSize;
 	size_t lineSize;
-	size_t numLines;
+	size_t linesCnt;
 	size_t numSets;
 
 	uint64_t tagMask;
@@ -101,16 +101,16 @@ static uint64_t cache_generateMask(int numBits)
 }
 
 
-cachectx_t *cache_init(size_t srcMemSize, size_t size, size_t lineSize, const cache_ops_t *ops)
+cachectx_t *cache_init(size_t srcMemSize, size_t lineSize, size_t linesCnt, const cache_ops_t *ops)
 {
 	int err;
 	cachectx_t *cache = NULL;
 
-	if (srcMemSize == 0 || size == 0 || lineSize == 0) {
+	if (srcMemSize == 0 || linesCnt == 0 || lineSize == 0) {
 		return NULL;
 	}
 
-	if (size % lineSize != 0 || (size / lineSize) % LIBCACHE_NUM_WAYS != 0) {
+	if (linesCnt % LIBCACHE_NUM_WAYS != 0) {
 		return NULL;
 	}
 
@@ -119,9 +119,9 @@ cachectx_t *cache_init(size_t srcMemSize, size_t size, size_t lineSize, const ca
 	if (cache != NULL) {
 		cache->srcMemSize = srcMemSize;
 		cache->lineSize = lineSize;
-		cache->numLines = size / cache->lineSize;
+		cache->linesCnt = linesCnt;
 
-		cache->numSets = cache->numLines / LIBCACHE_NUM_WAYS;
+		cache->numSets = cache->linesCnt / LIBCACHE_NUM_WAYS;
 
 		cache->sets = calloc(cache->numSets, sizeof(cacheset_t));
 

--- a/libcache/cache.h
+++ b/libcache/cache.h
@@ -43,8 +43,7 @@ typedef struct {
 } cache_ops_t;
 
 
-cachectx_t *cache_init(size_t srcMemSize, size_t size, size_t lineSize, const cache_ops_t *ops);
-
+cachectx_t *cache_init(size_t srcMemSize, size_t lineSize, size_t linesCnt, const cache_ops_t *ops);
 
 int cache_deinit(cachectx_t *cache);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The `size_t size` argument of `cache_init` function has been removed from the function prototype and `size_t linesCnt` has been added instead. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change shifts the responsibility of proper cache configuration from the user onto the library.

Now, the `cache_init` header is more intuitive as it resembles the typical formulation of function prototypes, e.g. from standard library:
-  _elementSize_ and _numOfElements_ (new API) vs.
-  _elementSize_ and _sizeOfAllElementsCombined_ (old API),

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
