### PR TITLE
libstorage: add mountpoint info to mounted filesystems

### DIFF
--- a/libstorage/include/storage/fs.h
+++ b/libstorage/include/storage/fs.h
@@ -47,6 +47,7 @@ typedef struct {
 
 
 typedef struct {
+	oid_t *mnt;                     /* Filesystem mountpoint (NULL if mounted as rootfs) */
 	void *info;                     /* Specific information for the filesystem */
 	const storage_fsops_t *ops;     /* Callbacks to operations on the filesystem */
 	struct _storage_fsctx_t *fsctx; /* File system context used internally by the storage library */

--- a/libstorage/include/storage/storage.h
+++ b/libstorage/include/storage/storage.h
@@ -48,7 +48,11 @@ extern int storage_unregisterfs(const char *name);
 
 
 /* Mounts filesystem */
-extern int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *root);
+extern int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *mnt, oid_t *root);
+
+
+/* Returns filesystem mountpoint (-ENOENT is returned if storage is mounted as rootfs) */
+extern int storage_mountpoint(storage_t *strg, oid_t *mnt);
 
 
 /* Unmounts filesystem */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added mount point oid stored for every mounted filesystem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for `umount()` functionality in order to retrieve mountpoint from a mounted device.
[JIRA: RTOS-293](https://jira.phoenix-rtos.com/browse/RTOS-293)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
