### PR TITLE
libstorage: add mountpoint info to mounted filesystems

### DIFF
--- a/libstorage/include/storage/fs.h
+++ b/libstorage/include/storage/fs.h
@@ -47,6 +47,7 @@ typedef struct {
 
 
 typedef struct {
+	oid_t *mnt;                     /* Filesystem mountpoint (NULL if mounted as rootfs) */
 	void *info;                     /* Specific information for the filesystem */
 	const storage_fsops_t *ops;     /* Callbacks to operations on the filesystem */
 	struct _storage_fsctx_t *fsctx; /* File system context used internally by the storage library */

--- a/libstorage/include/storage/storage.h
+++ b/libstorage/include/storage/storage.h
@@ -48,7 +48,11 @@ extern int storage_unregisterfs(const char *name);
 
 
 /* Mounts filesystem */
-extern int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *root);
+extern int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *mnt, oid_t *root);
+
+
+/* Returns filesystem mountpoint (-ENOENT is returned if storage is mounted as rootfs) */
+extern int storage_mountpoint(storage_t *strg, oid_t *mnt);
 
 
 /* Unmounts filesystem */

--- a/libstorage/storage.c
+++ b/libstorage/storage.c
@@ -444,6 +444,8 @@ int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigne
 	root->port = fsctx->reqctx.port;
 	/* Pointer to the storage_fs_t is hold by a request context and passed to a message handler */
 	fsctx->reqctx.data = strg->fs;
+	/* Set filesystem handler */
+	fsctx->handler = handler;
 	/* The filesystem context has to be assign to the storage_fs_t to make umount operation */
 	strg->fs->fsctx = fsctx;
 

--- a/libstorage/storage.c
+++ b/libstorage/storage.c
@@ -394,7 +394,7 @@ int storage_unregisterfs(const char *name)
 }
 
 
-int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *root)
+int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigned long mode, oid_t *mnt, oid_t *root)
 {
 	int err;
 	storage_fsctx_t *fsctx;
@@ -416,9 +416,25 @@ int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigne
 		return -ENOMEM;
 	}
 
+	/* Set filesystem mountpoint */
+	if (mnt != NULL) {
+		strg->fs->mnt = malloc(sizeof(oid_t));
+		if (strg->fs->mnt == NULL) {
+			free(fsctx);
+			free(strg->fs);
+			return -ENOMEM;
+		}
+		*strg->fs->mnt = *mnt;
+	}
+	/* Mounting rootfs, no mountpoint */
+	else {
+		strg->fs->mnt = NULL;
+	}
+
 	err = storagectx_init(&fsctx->reqctx, storage_fsHandler);
 	if (err < 0) {
 		free(fsctx);
+		free(strg->fs->mnt);
 		free(strg->fs);
 		strg->fs = NULL;
 		return err;
@@ -435,12 +451,29 @@ int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigne
 	if (err < 0) {
 		requestctx_done(&fsctx->reqctx);
 		free(fsctx);
+		free(strg->fs->mnt);
 		free(strg->fs);
 		strg->fs = NULL;
 		return err;
 	}
 
 	requestctx_run(&fsctx->reqctx);
+
+	return EOK;
+}
+
+
+int storage_mountpoint(storage_t *strg, oid_t *mnt)
+{
+	if ((strg == NULL) || (strg->fs == NULL) || (mnt == NULL)) {
+		return -EINVAL;
+	}
+
+	/* Mounted rootfs, no mountpoint */
+	if (strg->fs->mnt == NULL) {
+		return -ENOENT;
+	}
+	*mnt = *strg->fs->mnt;
 
 	return EOK;
 }
@@ -465,6 +498,7 @@ int storage_umountfs(storage_t *strg)
 
 	requestctx_done(&fsctx->reqctx);
 	free(fsctx);
+	free(strg->fs->mnt);
 	free(strg->fs);
 
 	strg->fs = NULL;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Added mount point oid stored for every mounted filesystem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[JIRA: RTOS-293](https://jira.phoenix-rtos.com/browse/RTOS-293)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7a7-imx6ull

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
