### PR TITLE
Add mtDevCtl support to storage_fsHandler

### DIFF
--- a/libstorage/fs.c
+++ b/libstorage/fs.c
@@ -3,8 +3,8 @@
  *
  * Filesystem interface
  *
- * Copyright 2022 Phoenix Systems
- * Author: Hubert Buczynski, Lukasz Kosinski
+ * Copyright 2022, 2023 Phoenix Systems
+ * Author: Hubert Buczynski, Lukasz Kosinski, Hubert Badocha
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -38,7 +38,7 @@ void storage_fsHandler(void *data, msg_t *msg)
 				msg->o.io.err = -ENOSYS;
 				break;
 			}
-			fs->ops->open(fs->info, &msg->i.openclose.oid);
+			msg->o.io.err = fs->ops->open(fs->info, &msg->i.openclose.oid);
 			break;
 
 		case mtClose:
@@ -46,7 +46,7 @@ void storage_fsHandler(void *data, msg_t *msg)
 				msg->o.io.err = -ENOSYS;
 				break;
 			}
-			fs->ops->close(fs->info, &msg->i.openclose.oid);
+			msg->o.io.err = fs->ops->close(fs->info, &msg->i.openclose.oid);
 			break;
 
 		case mtRead:
@@ -74,7 +74,11 @@ void storage_fsHandler(void *data, msg_t *msg)
 			break;
 
 		case mtDevCtl:
-			msg->o.io.err = -EINVAL;
+			if (fs->ops->devctl == NULL) {
+				msg->o.io.err = -ENOSYS;
+				break;
+			}
+			(void)fs->ops->devctl(fs->info, &msg->i.io.oid, msg->i.raw, msg->o.raw);
 			break;
 
 		case mtCreate:


### PR DESCRIPTION
JIRA: RTOS-346

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add mtDevCtl support.
Add errors support to mtOpen and mtClose.

## Motivation and Context
Meterfs starts to use libstorage. It needs proper mtDevCtl support in order to work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: imx6ull.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
