### PR TITLE
libptable: don't include board_config for host

### DIFF
--- a/libptable/ptable.c
+++ b/libptable/ptable.c
@@ -16,8 +16,14 @@
 #include <stddef.h>
 #include <string.h>
 
-/* Per project board configuration may overwrite PTABLE_CHECKSUM definition */
+/* Per project board configuration may overwrite PTABLE_CHECKSUM definition
+ * When compiling for linux host board config is not needed, associated with issue #671
+ * It allows building host-utils separately for host-generic-pc
+ */
+
+#ifndef __linux__
 #include <board_config.h>
+#endif
 
 #include "ptable.h"
 


### PR DESCRIPTION
It allows building host-utils separately

JIRA: CI-254

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
