### PR TITLE
ptable: Remove board_config.h dependency

### DIFF
--- a/libptable/ptable.h
+++ b/libptable/ptable.h
@@ -16,6 +16,11 @@
 
 #include <stdint.h>
 
+/* Changelog:
+ * version 2: Add checksum and version fields
+ */
+#define PTABLE_VERSION 2
+
 
 /* Structure of partition table
  *  _________________________________________________________________________
@@ -48,7 +53,8 @@ typedef struct {
 
 typedef struct {
 	uint32_t count;         /* Number of partitions */
-	uint8_t reserved[20];   /* Reserved bytes */
+	uint8_t version;        /* Ptable struct version */
+	uint8_t reserved[19];   /* Reserved bytes */
 	uint32_t crc;           /* Header checksum */
 	ptable_part_t parts[0]; /* Partitions */
 } ptable_t;


### PR DESCRIPTION
Use new version field to enable/disable CRC check

DONE: RTOS-422

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
My proposition for enabling/disabling CRC checks in runtime - add additional version field to disable checks only on legacy ptables (that did not have this version field).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
