### PR TITLE
libstorage: remove redundant lock unlock

### DIFF
--- a/libstorage/storage.c
+++ b/libstorage/storage.c
@@ -28,7 +28,9 @@
 #define POOLTHR_PRIORITY 1
 
 
+/* clang-format off */
 enum { state_exit = -1, state_stop, state_run };
+/* clang-format on */
 
 
 typedef struct {
@@ -145,9 +147,8 @@ static void storage_reqthr(void *arg)
 	request_t *req = NULL;
 	int err;
 
+	mutexLock(ctx->lock);
 	for (;;) {
-		mutexLock(ctx->lock);
-
 		while ((ctx->state != state_exit) && ((ctx->state == state_stop) || ((req = queue_pop(&storage_common.free)) == NULL)))
 			condWait(storage_common.fcond, ctx->lock, 0);
 
@@ -181,8 +182,6 @@ static void storage_reqthr(void *arg)
 			queue_push(&storage_common.ready, req);
 			condSignal(storage_common.rcond);
 		}
-
-		mutexUnlock(ctx->lock);
 	}
 }
 
@@ -439,7 +438,7 @@ int storage_mountfs(storage_t *strg, const char *name, const char *data, unsigne
 
 	/* Assign the port to a filesystem from a newly created request context */
 	root->port = fsctx->reqctx.port;
-	/* Pointer to the storage_fs_t is hold by a request context and passed to a message handler */
+	/* Pointer to the storage_fs_t is held by a request context and passed to a message handler */
 	fsctx->reqctx.data = strg->fs;
 	/* Set filesystem handler */
 	fsctx->handler = handler;


### PR DESCRIPTION
JIRA: RTOS-468

<!--- Provide a general summary of your changes in the Title above -->

## Description
Recent changes in libstorage shed light onto a fact that `storage_reqthr` locks the same mutex at the begging of the for loop as it unlocks at the end.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
