### PR TITLE
libgraph: adjust TARGET define on riscv64

### DIFF
--- a/libgraph/virtio-gpu.c
+++ b/libgraph/virtio-gpu.c
@@ -28,7 +28,7 @@
 
 
 /* Use polling on RISCV64 (interrupts trigger memory protection exception) */
-#ifdef TARGET_RISCV64
+#ifdef __TARGET_RISCV64
 #define USE_POLLING
 #endif
 
@@ -199,7 +199,7 @@ typedef struct {
 /* VirtIO GPU device descriptors */
 static const virtio_devinfo_t info[] = {
 	{ .type = vdevPCI, .id = 0x1050 },
-#ifdef TARGET_RISCV64
+#ifdef __TARGET_RISCV64
 	/* Direct VirtIO MMIO QEMU GPU device descriptors */
 	{ .type = vdevMMIO, .id = 0x10, .irq = 8, .base = { (void *)0x10008000, 0x1000 } },
 	{ .type = vdevMMIO, .id = 0x10, .irq = 7, .base = { (void *)0x10007000, 0x1000 } },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The reason for this is a recent change to phoenix-rtos-build which provides `__TARGET` and `__CPU` globally.
`TARGET_RISCV64` becomes `__TARGET_RISCV64` and `__CPU_GENERIC`.

JIRA: RTOS-519

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
