### PR TITLE
libstorage: Fix ioctl() handling on fs

### DIFF
--- a/libstorage/fs.c
+++ b/libstorage/fs.c
@@ -75,10 +75,12 @@ void storage_fsHandler(void *data, msg_t *msg)
 
 		case mtDevCtl:
 			if (fs->ops->devctl == NULL) {
-				msg->o.io.err = -ENOSYS;
+				/* FIXME this error passing works by accident on ioctl(),
+				 * there's no dedicated error field for devctl. */
+				msg->o.io.err = -ENOTTY; /* To return valid errno on ioctl() */
 				break;
 			}
-			(void)fs->ops->devctl(fs->info, &msg->i.io.oid, msg->i.raw, msg->o.raw);
+			fs->ops->devctl(fs->info, &msg->i.io.oid, msg->i.raw, msg->o.raw);
 			break;
 
 		case mtCreate:

--- a/libstorage/include/storage/fs.h
+++ b/libstorage/include/storage/fs.h
@@ -32,7 +32,7 @@ typedef struct {
 	int (*setattr)(void *info, oid_t *oid, int type, long long attr, void *data, size_t len);
 	int (*getattr)(void *info, oid_t *oid, int type, long long *attr);
 	int (*truncate)(void *info, oid_t *oid, size_t size);
-	int (*devctl)(void *info, oid_t *oid, const void *in, void *out);
+	void (*devctl)(void *info, oid_t *oid, const void *in, void *out);
 
 	int (*create)(void *info, oid_t *oid, const char *name, oid_t *dev, unsigned mode, int type, oid_t *res);
 	int (*destroy)(void *info, oid_t *oid);


### PR DESCRIPTION
- return devctl error only via output argument,
- return -ENOTTY when no devctl handler is provided to return valid errno from ioctl()

JIRA: RTOS-525

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
